### PR TITLE
Fix currentSvgFilename null check

### DIFF
--- a/js/exportUtils.js
+++ b/js/exportUtils.js
@@ -162,7 +162,7 @@ function exportSTL() {
                             const exporter = new THREE.STLExporter();
                             const result = exporter.parse(exportGroup, { binary: true });
                             
-                            const sanitizedName = typeof currentSvgFilename !== 'undefined' ? 
+                            const sanitizedName = (typeof currentSvgFilename !== 'undefined' && currentSvgFilename !== null) ? 
                                 currentSvgFilename.replace(/[^\w\-\.]/g, '_') : 'stampforge';
                             const filename = `stampForge_${sanitizedName}.stl`;
                             


### PR DESCRIPTION
The code was throwing `Error generating STL file: currentSvgFilename is null`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved filename handling to prevent errors when exporting files with missing or invalid names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->